### PR TITLE
 Add a column in the list view for the VM's cluster host

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ All of the commands support the following options:
 | `--password` | Your vSphere password (or specify via `ENV['LDAP_PASSWORD']`) |
 | `--datacenter` | The vSphere datacenter |
 | `--cluster` | The vSphere cluster |
-| `--vmpooler` | A comma-separated list of vmpooler redis hostnames to reconcile VMs against |
+| `--vmpoolers` | A comma-separated list of vmpooler redis hostnames to reconcile VMs against |
 
 ### Summary
 
@@ -80,6 +80,30 @@ Number of VMs not associated with any Jenkins job
       0 unknown
 
 Efficiency 5.4%, 90 out of 1657 VMs are doing useful work
+
+Cluster host count of VM
+N/A 637
+opdx-a0-chassis5-1.ops.puppetlabs.net 88
+opdx-a0-chassis5-2.ops.puppetlabs.net 109
+opdx-a0-chassis5-3.ops.puppetlabs.net 119
+opdx-a0-chassis5-4.ops.puppetlabs.net 54
+opdx-a0-chassis5-5.ops.puppetlabs.net 124
+opdx-a0-chassis5-6.ops.puppetlabs.net 87
+opdx-a0-chassis5-7.ops.puppetlabs.net 116
+opdx-a0-chassis5-8.ops.puppetlabs.net 94
+opdx-a2-chassis6-1.ops.puppetlabs.net 111
+opdx-a2-chassis6-2.ops.puppetlabs.net 77
+opdx-a2-chassis6-3.ops.puppetlabs.net 114
+opdx-a2-chassis6-4.ops.puppetlabs.net 98
+opdx-a2-chassis6-5.ops.puppetlabs.net 69
+opdx-a2-chassis6-6.ops.puppetlabs.net 132
+opdx-a2-chassis6-7.ops.puppetlabs.net 91
+opdx-a2-chassis6-8.ops.puppetlabs.net 62
+opdx-e6-chassis8-1.ops.puppetlabs.net 105
+opdx-e6-chassis8-2.ops.puppetlabs.net 87
+opdx-e6-chassis8-3.ops.puppetlabs.net 111
+opdx-e6-chassis8-4.ops.puppetlabs.net 63
+opdx-e6-chassis8-5.ops.puppetlabs.net 110
 ```
 
 ### List
@@ -88,21 +112,21 @@ List the status of each VM:
 
 ```
 $ bundle exec vmstatus list --host vcenter --user user@foo.com
-Querying vsphere 'vcenter' for VMs in cluster 'cluster1' in datacenter dc1'
+Querying vsphere 'vcenter' for VMs in cluster 'cluster1' in datacenter dc1' for vmpoolers x,y,z
 Processing 1670 VMs, ignoring 243 templates
 Time: 00:06:41 ====================================================================================== 100% Progress
 
-Hostname        Status    Running  Checkout Time                     TTL User                Jenkins Job
-afzowkwedv1m39e aborted    on/*    2017-01-24T12:53:06-08:00       7.11h jenkins             enterprise_pe-orchestrator_integration-system_smoke-flanders
-bv3qyq0f9bkphb2 adhoc      on/*    2017-01-24T08:05:14-08:00       2.31h kermit
-a21vj6t37jxqq4t building   on/*    2017-01-24T17:35:46-08:00      11.82h jenkins             enterprise_pe-acceptance-tests_integration-system_pe_smoke-split_2017.2.x
-bwbgwxs4qdss18w failed     on/*    2017-01-24T09:26:39-08:00       3.67h jenkins             enterprise_puppet-code_intn-van-sys_flanders
-dpisyffpvy3d9if orphaned   on/*                                    never
-bnzks2bgm1sb8gn ready      on/*                                    never
-yt42hvi9qvzfs6i ready      on/!                                    never
+Hostname        Cluster Host                                 Type                   Pooler  Status    Running  Checkout Time                     TTL User                 Jenkins Job
+afzowkwedv1m39e blah-a0-chassis1-1.puppet                    centos-7-x86_64        ci-next aborted    on/*    2017-01-24T12:53:06-08:00       7.11h jenkins             enterprise_pe-orchestrator_integration-system_smoke-flanders
+bv3qyq0f9bkphb2 blah-a0-chassis1-2.puppet                    ubuntu-1404-x86_64     ci-dev  adhoc      on/*    2017-01-24T08:05:14-08:00       2.31h kermit
+a21vj6t37jxqq4t blah-a0-chassis1-1.puppet                    redhat-7-x86_64        ci-next building   on/*    2017-01-24T17:35:46-08:00      11.82h jenkins             enterprise_pe-acceptance-tests_integration-system_pe_smoke-split_2017.2.x
+bwbgwxs4qdss18w blah-a0-chassis1-3.puppet                    redhat-7-x86_64        ci-next failed     on/*    2017-01-24T09:26:39-08:00       3.67h jenkins             enterprise_puppet-code_intn-van-sys_flanders
+dpisyffpvy3d9if blah-a0-chassis1-1.puppet                    redhat-7-x86_64        ci-next orphaned   on/*                                    never
+bnzks2bgm1sb8gn blah-a0-chassis1-2.puppet                    redhat-7-x86_64        ci-next ready      on/*                                    never
+yt42hvi9qvzfs6i blah-a0-chassis1-1.puppet                    redhat-7-x86_64        ci-next ready      on/!                                    never
 ```
 
-This displays each VM sorted by hostname along with its status, running state, checkout time, vmpooler TTL, user the VM is checked out to, and the Jenkins Job the VM is associated with.
+This displays each VM sorted by hostname along with its Cluster host (the vsphere host name), VM tpye, pooler, status, running state, checkout time, vmpooler TTL, user the VM is checked out to, and the Jenkins Job the VM is associated with.
 
 Vmstatus reports on the running state of the VM as reported by vSphere, e.g. "on". The "*" means the VM's hostname is resolvable and we can make a TCP connection to port 22. An "!" means we failed to connect, even though the VM is running according to vSphere. That can be due to transient network errors, DNS failures, the VM failed to respond within a specified timeout, the VM is unresponsive, etc.
 

--- a/lib/vmstatus/list.rb
+++ b/lib/vmstatus/list.rb
@@ -6,8 +6,9 @@ class Vmstatus::List
   def output(results)
     puts ""
 
-    puts "Hostname".ljust(16) + "Type".ljust(23) + "Pooler".ljust(8) + "Status".ljust(10) + "Running".ljust(9) + "Checkout Time".ljust(25) + "TTL".rjust(12) + " User".ljust(22) + "Jenkins Job"
+    puts "Hostname".ljust(16) + "Cluster Host".ljust(45) + "Type".ljust(23) + "Pooler".ljust(8) + "Status".ljust(10) + "Running".ljust(9) + "Checkout Time".ljust(25) + "TTL".rjust(12) + " User".ljust(22) + "Jenkins Job"
 
+    countcluster = Hash.new
     results.vms.sort_by do |vm|
       case @opts[:sort]
       when 'checkout'
@@ -55,12 +56,24 @@ class Vmstatus::List
                else
                  vm.vmpooler || 'none'
                end
-      left = hostname.ljust(16) + type.ljust(23) + pooler.ljust(8) + vm.status.ljust(10) + on.rjust(3) + "/" + running.ljust(5) + checkout.ljust(25) + ttl.rjust(12) + " " + user.ljust(20)
+      clusterhost = vm.clusterhost ? vm.clusterhost : "N/A"
+      left = hostname.ljust(16) + clusterhost.ljust(45) + type.ljust(23) + pooler.ljust(8) + vm.status.ljust(10) + on.rjust(3) + "/" + running.ljust(5) + checkout.ljust(25) + ttl.rjust(12) + " " + user.ljust(20)
       right = @opts.long? ? vm.url : vm.job_name
 
       puts "#{left} #{right}".colorize(color)
+
+      # count for each cluster host
+      if !countcluster[clusterhost]
+        countcluster[clusterhost] = 1
+      else
+        countcluster[clusterhost] = countcluster[clusterhost] + 1
+      end
     end
 
     puts ""
+    puts "Cluster host count of VM"
+    countcluster.sort_by {|host, count| host}.each do |host, count|
+      puts "#{host} #{count}"
+    end
   end
 end

--- a/lib/vmstatus/summary.rb
+++ b/lib/vmstatus/summary.rb
@@ -37,6 +37,23 @@ class Vmstatus::Summary
 
     puts "Efficiency %.1f%%, #{useful_vms} out of #{total_vms} VMs are doing useful work" % eff
 
+    puts ""
+    countcluster = Hash.new
+    results.vms.each do |vm|
+      clusterhost = vm.clusterhost ? vm.clusterhost : "N/A"
+      # count for each cluster host
+      if !countcluster[clusterhost]
+        countcluster[clusterhost] = 1
+      else
+        countcluster[clusterhost] = countcluster[clusterhost] + 1
+      end
+    end
+
+    puts "Cluster host count of VM"
+    countcluster.sort_by {|host, count| host}.each do |host, count|
+      puts "#{host} #{count}"
+    end
+
     if @opts[:publish]
       begin
         host, port = @opts[:publish].split(':')
@@ -54,6 +71,10 @@ class Vmstatus::Summary
             count = arr.nil? ? 0 : arr.count
             statsd.gauge("#{vmpooler}.#{state}", count)
           end
+        end
+
+        countcluster.each do |host, count|
+          statsd.gauge("host.#{host}", count)
         end
       rescue ArgumentError => e
         raise ArgumentError.new("Invalid publish host:port #{@opts[:publish]}: #{e.message}")

--- a/lib/vmstatus/vm.rb
+++ b/lib/vmstatus/vm.rb
@@ -2,7 +2,7 @@ require 'date'
 require 'time'
 
 class Vmstatus::VM
-  attr_reader :hostname, :uuid, :url, :type, :user, :checkout, :ttl, :status, :vmpooler
+  attr_reader :hostname, :uuid, :url, :type, :user, :checkout, :ttl, :status, :vmpooler, :clusterhost
 
   def initialize(hostname)
     @hostname = hostname
@@ -59,6 +59,7 @@ class Vmstatus::VM
   def vsphere_status=(status)
     @on   = status[:on]
     @uuid = status[:uuid]
+    @clusterhost = status[:clusterhost]
   end
 
   def vmpooler_status=(status)

--- a/lib/vmstatus/vsphere_task.rb
+++ b/lib/vmstatus/vsphere_task.rb
@@ -8,10 +8,11 @@ class Vmstatus::VsphereTask
     @password = opts[:password]
     @datacenter = opts[:datacenter]
     @cluster = opts[:cluster]
+    @vmpoolers = opts[:vmpoolers]
   end
 
   def run(&block)
-    puts "Querying vsphere '#{@host}' for VMs in cluster '#{@cluster}' in datacenter '#{@datacenter}'"
+    puts "Querying vsphere '#{@host}' for VMs in cluster '#{@cluster}' in datacenter '#{@datacenter}' for vmpoolers " + @vmpoolers.join(", ")
 
     with_connection do |conn|
       dc = conn.serviceInstance.find_datacenter(@datacenter)
@@ -66,7 +67,7 @@ class Vmstatus::VsphereTask
         }
       ],
       propSet: [
-        { type: 'VirtualMachine', pathSet: %w(name config.instanceUuid runtime.powerState) }
+        { type: 'VirtualMachine', pathSet: %w(name config.instanceUuid runtime.powerState runtime.host) }
       ]
     )
 
@@ -76,7 +77,8 @@ class Vmstatus::VsphereTask
       if !template_uuids.include?(obj['config.instanceUuid'])
         vsphere_status = {
           :uuid => obj['config.instanceUuid'],
-          :on => obj['runtime.powerState']
+          :on => obj['runtime.powerState'],
+          :clusterhost => obj['runtime.host'].name
         }
         yield obj['name'], vsphere_status
       end


### PR DESCRIPTION
and a count of VMs for each host.  In `summary` and `-publish` mode, the count will also get published to statsd under stats.gauges.vmstatus.host.*.ops.puppetlabs.net